### PR TITLE
New overview

### DIFF
--- a/README
+++ b/README
@@ -61,6 +61,3 @@ Files:
 -----
 Favorite Channel List is in favorites.conf
 Configuration settings are stored in VDR's setup.conf
-
-
-

--- a/README
+++ b/README
@@ -53,6 +53,7 @@ red	 Remove selected favorite channel from list.
 green	 Add current chennel to favorite channel list.
 Yellow	 Move selected favorite channel up in the list.
 Blue	 Move selected favorite channel down in the list.
+8        Show next event
 back	 close the plugin
 
 

--- a/config.h
+++ b/config.h
@@ -6,6 +6,7 @@ struct sFavoriteConfig
    int closeonswitch;
    int sortby;
    int hidemainmenuentry;
+   int showepg;
 };
 
 extern sFavoriteConfig config;

--- a/config.h
+++ b/config.h
@@ -7,6 +7,7 @@ struct sFavoriteConfig
    int sortby;
    int hidemainmenuentry;
    int showepg;
+   int progressview;
 };
 
 extern sFavoriteConfig config;

--- a/favoriteosd.c
+++ b/favoriteosd.c
@@ -215,7 +215,6 @@ void cFavoriteOsd::AddMenuEntry(int favId) {
                      t, v, r,
                      event ? szEventDescr : " ");
 
-        printf("%s\n", buffer);
         Add (new cOsdItem(buffer));
     }
 }

--- a/favoriteosd.c
+++ b/favoriteosd.c
@@ -95,7 +95,7 @@ void cFavoriteOsd::DisplayFavorites()
 {
    Clear();
 
-   SetCols(15, 5, 5, 4);
+   SetCols(17, 5, 5, 4);
 
    for (int i=0; i<number; i++)
    {
@@ -156,7 +156,7 @@ void cFavoriteOsd::AddMenuEntry(int favId) {
         }
 
         char szChannelpart[20] = "";
-        snprintf(szChannelpart, 20, "%s\t", channel->Name());
+        snprintf(szChannelpart, 20, "%s", channel->Name());
 
         char szProgressPart[50] = "";
         if (event) {
@@ -208,7 +208,7 @@ void cFavoriteOsd::AddMenuEntry(int favId) {
         }
 
         char *buffer = NULL;
-        asprintf(&buffer, "%s%s\t%s %c%c%c \t%s",
+        asprintf(&buffer, "%s\t%s\t%s %c%c%c \t%s",
                  szChannelpart,
                  event?*(event->GetTimeString() ):"",
                  szProgressPart,

--- a/favoriteosd.c
+++ b/favoriteosd.c
@@ -95,7 +95,7 @@ void cFavoriteOsd::DisplayFavorites()
 {
    Clear();
 
-   SetCols(17, 5, 5, 4);
+   SetCols(17, 5, 10, 4);
 
    for (int i=0; i<number; i++)
    {
@@ -132,7 +132,7 @@ void cFavoriteOsd::AddMenuEntry(int favId) {
     char t = ' ';
     char v = ' ';
     char r = ' ';
-    char szEventDescr[100] = "";
+    char szEventDescr[100] = " ";
 
     LOCK_TIMERS_READ;
     LOCK_CHANNELS_READ;
@@ -179,7 +179,7 @@ void cFavoriteOsd::AddMenuEntry(int favId) {
                             ProgressBar += Icons::ProgressEmpty();
                     }
                     ProgressBar += Icons::ProgressEnd();
-                    sprintf(szProgressPart, "%s\t", ProgressBar.c_str());
+                    sprintf(szProgressPart, "%s", ProgressBar.c_str());
                     break;
 
                 case 0:
@@ -189,7 +189,7 @@ void cFavoriteOsd::AddMenuEntry(int favId) {
                     for (int i = 0; i < fracInt; i++)
                         szProgress[i] = '|';
                     szProgress[fracInt] = 0;
-                    sprintf(szProgressPart, "%c%-8s%c\t", '[', szProgress, ']');
+                    sprintf(szProgressPart, "%c%-8s%c", '[', szProgress, ']');
                     break;
 
                 default:
@@ -208,13 +208,14 @@ void cFavoriteOsd::AddMenuEntry(int favId) {
         }
 
         char *buffer = NULL;
-        asprintf(&buffer, "%s\t%s\t%s %c%c%c \t%s",
-                 szChannelpart,
-                 event?*(event->GetTimeString() ):"",
-                 szProgressPart,
-                 t, v, r,
-                 szEventDescr);
+            asprintf(&buffer, "%s\t%s\t%s\t %c%c%c \t%s",
+                     szChannelpart,
+                     event ? *(event->GetTimeString()) : "    ",
+                     event ? szProgressPart : "          ",
+                     t, v, r,
+                     event ? szEventDescr : " ");
 
+        printf("%s\n", buffer);
         Add (new cOsdItem(buffer));
     }
 }

--- a/favoriteosd.h
+++ b/favoriteosd.h
@@ -8,6 +8,7 @@ class cFavoriteOsd : public cOsdMenu
 {
    private:
       tChannelID lastChannel;
+      void AddMenuEntry(int favId);
 
    public:
       cFavoriteOsd(void);
@@ -24,6 +25,8 @@ class cFavoriteOsd : public cOsdMenu
 
    private:
       int current;
+      bool now;
 
 };
+
 #endif                           //__FAVORITEOSD_H

--- a/favoriteosd.h
+++ b/favoriteosd.h
@@ -29,4 +29,29 @@ class cFavoriteOsd : public cOsdMenu
 
 };
 
+class Icons
+{
+private:
+    static bool IsUTF8;
+public:
+    static void InitCharSet();
+    static const char* Continue(){return IsUTF8?"\ue000":"\x80";}
+    static const char* DVD(){return IsUTF8?"\ue001":"\x81";}
+    static const char* Directory(){return IsUTF8?"\ue002":"\x82";}
+    static const char* FixedBlank(){return IsUTF8?"\ue003":"\x83";}
+    static const char* Scissor(){return IsUTF8?"\ue004":"\x84";}
+    static const char* MovingRecording(){return IsUTF8?"\ue005":"\x85";}
+    static const char* MovingDirectory(){return IsUTF8?"\ue006":"\x86";}
+    static const char* ProgressStart(){return IsUTF8?"\ue007":"\x87";}
+    static const char* ProgressFilled(){return IsUTF8?"\ue008":"\x88";}
+    static const char* ProgressEmpty(){return IsUTF8?"\ue009":"\x89";}
+    static const char* ProgressEnd(){return IsUTF8?"\ue00a":"\x8a";}
+    static const char* Recording(){return IsUTF8?"\ue00b":"\x8b";}
+    static const char* AlarmClock(){return IsUTF8?"\ue00c":"\x8c";}
+    static const char* TVScrambled(){return IsUTF8?"\ue00d":"\x8d";}
+    static const char* Radio(){return IsUTF8?"\ue00e":"\x8e";}
+    static const char* TV(){return IsUTF8?"\ue00f":"\x8f";}
+    static const char* New(){return IsUTF8?"\ue010":"\x90";}
+};
+
 #endif                           //__FAVORITEOSD_H

--- a/favorites.c
+++ b/favorites.c
@@ -118,6 +118,7 @@ bool cPluginFavorites::SetupParse(const char *Name, const char *Value)
    if (!strcasecmp(Name, "CloseOnSwitch"))          config.closeonswitch = atoi(Value);
    else if (!strcasecmp(Name, "SortBy"))            config.sortby = atoi(Value);
    else if (!strcasecmp(Name, "HideMainMenuEntry")) config.hidemainmenuentry = atoi(Value);
+   else if (!strcasecmp(Name, "ShowEPG"))           config.showepg = atoi(Value);
    else
       return false;
 
@@ -127,5 +128,5 @@ bool cPluginFavorites::SetupParse(const char *Name, const char *Value)
 
 sFavoriteConfig config;
 
-                                 // Don't touch this!
+// Don't touch this!
 VDRPLUGINCREATOR(cPluginFavorites);

--- a/favorites.c
+++ b/favorites.c
@@ -73,6 +73,7 @@ bool cPluginFavorites::Start(void)
 {
    // Start any background activities the plugin shall perform.
    // Default values for setup
+   Icons::InitCharSet();
    return true;
 }
 
@@ -119,6 +120,7 @@ bool cPluginFavorites::SetupParse(const char *Name, const char *Value)
    else if (!strcasecmp(Name, "SortBy"))            config.sortby = atoi(Value);
    else if (!strcasecmp(Name, "HideMainMenuEntry")) config.hidemainmenuentry = atoi(Value);
    else if (!strcasecmp(Name, "ShowEPG"))           config.showepg = atoi(Value);
+   else if (!strcasecmp(Name, "ProgressView"))      config.progressview = atoi(Value);
    else
       return false;
 

--- a/favoritesetup.c
+++ b/favoritesetup.c
@@ -12,18 +12,25 @@
 cFavoriteSetup::cFavoriteSetup(void)
 {
    CloseOnSwitch = config.closeonswitch;
-   SortBy      = config.sortby;
-   HideMainMenuEntry=config.hidemainmenuentry;
+   SortBy = config.sortby;
+   HideMainMenuEntry = config.hidemainmenuentry;
    ShowEPG = config.showepg;
+   ProgressView = config.progressview;
+
    SortOpt[0] = tr("as entered");
    SortOpt[1] = tr("none");
    SortOpt[2] = tr("name");
+
+   ProgressViewtStrs[0] = tr("old text bar");
+   ProgressViewtStrs[1] = tr("VDRSymbols");
+   ProgressViewtStrs[2] = tr("Percent");
+
    Add(new cMenuEditBoolItem(tr("Hide main menu entry"), &HideMainMenuEntry));
    Add(new cMenuEditBoolItem(tr("Close on switch"), &CloseOnSwitch));
    Add(new cMenuEditStraItem(tr("Sort by"), &SortBy, 3, SortOpt));
    Add(new cMenuEditBoolItem(tr("Show EPG"), &ShowEPG));
+   Add(new cMenuEditStraItem(tr("Progress view"), &ProgressView, 3, ProgressViewtStrs));
 }
-
 
 void cFavoriteSetup::Store(void)
 {
@@ -31,4 +38,5 @@ void cFavoriteSetup::Store(void)
    SetupStore("SortBy", config.sortby = SortBy);
    SetupStore("HideMainMenuEntry", config.hidemainmenuentry = HideMainMenuEntry);
    SetupStore("ShowEPG", config.showepg = ShowEPG);
+   SetupStore("ProgressView", config.progressview = ProgressView);
 }

--- a/favoritesetup.c
+++ b/favoritesetup.c
@@ -14,12 +14,14 @@ cFavoriteSetup::cFavoriteSetup(void)
    CloseOnSwitch = config.closeonswitch;
    SortBy      = config.sortby;
    HideMainMenuEntry=config.hidemainmenuentry;
+   ShowEPG = config.showepg;
    SortOpt[0] = tr("as entered");
    SortOpt[1] = tr("none");
    SortOpt[2] = tr("name");
    Add(new cMenuEditBoolItem(tr("Hide main menu entry"), &HideMainMenuEntry));
    Add(new cMenuEditBoolItem(tr("Close on switch"), &CloseOnSwitch));
    Add(new cMenuEditStraItem(tr("Sort by"), &SortBy, 3, SortOpt));
+   Add(new cMenuEditBoolItem(tr("Show EPG"), &ShowEPG));
 }
 
 
@@ -28,4 +30,5 @@ void cFavoriteSetup::Store(void)
    SetupStore("CloseOnSwitch", config.closeonswitch = CloseOnSwitch);
    SetupStore("SortBy", config.sortby = SortBy);
    SetupStore("HideMainMenuEntry", config.hidemainmenuentry = HideMainMenuEntry);
+   SetupStore("ShowEPG", config.showepg = ShowEPG);
 }

--- a/favoritesetup.h
+++ b/favoritesetup.h
@@ -7,10 +7,12 @@ class cFavoriteSetup : public cMenuSetupPage
 {
    private:
       const char *SortOpt[3];
+      const char* ProgressViewtStrs[3];
       int HideMainMenuEntry;
       int CloseOnSwitch;
       int SortBy;
       int ShowEPG;
+      int ProgressView;
 
    protected:
       virtual void Store(void);

--- a/favoritesetup.h
+++ b/favoritesetup.h
@@ -10,6 +10,8 @@ class cFavoriteSetup : public cMenuSetupPage
       int HideMainMenuEntry;
       int CloseOnSwitch;
       int SortBy;
+      int ShowEPG;
+
    protected:
       virtual void Store(void);
    public:

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.7.18\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2011-12-07 16:35+0100\n"
+"POT-Creation-Date: 2022-10-18 13:55+0200\n"
 "PO-Revision-Date: 2010-01-16 16:46+0100\n"
 "Last-Translator: gnapheus\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -31,6 +31,9 @@ msgstr "Hoch"
 msgid "Button$Down"
 msgstr "Runter"
 
+msgid "no info"
+msgstr "Keine Daten vorhanden"
+
 msgid "Favorite Channels Menu"
 msgstr "Lieblingskänale Menü"
 
@@ -46,6 +49,15 @@ msgstr "nichts"
 msgid "name"
 msgstr "Name"
 
+msgid "old text bar"
+msgstr "Text Balken"
+
+msgid "VDRSymbols"
+msgstr "VDRSymbols"
+
+msgid "Percent"
+msgstr "Prozent"
+
 msgid "Hide main menu entry"
 msgstr "Hauptmenüeintrag verstecken"
 
@@ -54,3 +66,9 @@ msgstr "Beim Umschalten schließen"
 
 msgid "Sort by"
 msgstr "Sortiert nach"
+
+msgid "Show EPG"
+msgstr "Zeige Sendungsinformationen"
+
+msgid "Progress view"
+msgstr "Fortschrittsanzeige"


### PR DESCRIPTION
Instead showing only the channel name in the favorite menu, i have copied functionality from Zaphistory to show also the current event and a progress bar.
Per default the behaviour of the plugin is completely unchanged. The new functionality needs to be enabled in the setup menu.